### PR TITLE
Resolved dictionary naming conflict

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-mysql:
+mauricios_mysql_defaults:
   install_server: True
   cnf:
     client:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,12 +1,12 @@
 ---
 - name: Include OS-specific variables.
   include_vars: "{{ ansible_os_family }}.yml"
-  
+
 - include: setup-RedHat.yml
   when: ansible_os_family == 'RedHat'
 
 - include: setup-Debian.yml
-  when: ansible_os_family == 'Debian'  
-  
+  when: ansible_os_family == 'Debian'
+
 - include: setup-server.yml
-  when: mysql.install_server  
+  when: mauricios_mysql_defaults.install_server  

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -1,7 +1,7 @@
 ---
 - name: Ensure MySQL client is present using apt
   sudo: yes
-  apt: 
+  apt:
     name: "{{ mysql['packages']['client'] }}"
     state: present
     update_cache: yes
@@ -9,10 +9,10 @@
 
 - name: Ensure MySQL server is present using apt
   sudo: yes
-  apt: 
+  apt:
     name: "{{ mysql['packages']['server'] }}"
     state: present
     update_cache: yes
     cache_valid_time: 86400
-  notify: start mysql  
-  when: mysql.install_server
+  notify: start mysql
+  when: mauricios_mysql_defaults.install_server

--- a/tasks/setup-RedHat.yml
+++ b/tasks/setup-RedHat.yml
@@ -1,24 +1,24 @@
 ---
 - name: Add the MySQL package repo to yum
   sudo: yes
-  yum: 
+  yum:
     name: http://repo.mysql.com/mysql-community-release-el7-5.noarch.rpm
 
 - name: Ensure MySQL client present using yum
   sudo: yes
-  yum: 
+  yum:
     name: "{{ mysql['packages']['client'] }}"
     state: present
-  
+
 - name: Ensure MySQL server present using yum
   sudo: yes
-  yum: 
+  yum:
     name: "{{ mysql['packages']['server'] }}"
     state: present
-  notify: start mysql   
-  when: mysql.install_server  
+  notify: start mysql
+  when: mauricios_mysql_defaults.install_server  
 
 - name: Set mysql to autostart on boot
   sudo: yes
   command: chkconfig --level 2345 mysqld on
-  when: mysql.install_server
+  when: mauricios_mysql_defaults.install_server

--- a/templates/etc/mysql/conf.d/my.cnf.j2
+++ b/templates/etc/mysql/conf.d/my.cnf.j2
@@ -3,14 +3,14 @@
 # TODO: Complenet default vars
 
 [client]
-port = {{ mysql["cnf"]["client"]["port"] | default("3306") }}
+port = {{ mauricios_mysql_defaults["cnf"]["client"]["port"] | default("3306") }}
 
 [mysqld]
-bind-address = {{ mysql["cnf"]["mysqld"]["bind-address"] | default("127.0.0.1")}}
-port = {{ mysql["cnf"]["client"]["port"] | default("3306") }}
+bind-address = {{ mauricios_mysql_defaults["cnf"]["mysqld"]["bind-address"] | default("127.0.0.1")}}
+port = {{ mauricios_mysql_defaults["cnf"]["client"]["port"] | default("3306") }}
 
 # * Fine Tuning
-key_buffer = {{ mysql["cnf"]["mysqld"]["key_buffer"] | default("16M") }}
+key_buffer = {{ mauricios_mysql_defaults["cnf"]["mysqld"]["key_buffer"] | default("16M") }}
 
 [mysqldump]
-max_allowed_packet = {{ mysql["cnf"]["mysqldump"]["max_allowed_packet"] | default("16M") }}
+max_allowed_packet = {{ mauricios_mysql_defaults["cnf"]["mysqldump"]["max_allowed_packet"] | default("16M") }}


### PR DESCRIPTION
The `mysql` dictionary defined in `defaults/main.yml` is overwritten in
`vars/Debian.yml` and `vars/RedHat.yml`. This commit renames the
dictionary to `mauricios_mysql_defaults` and updates the necessary
references.

Resolves Issue #1 
